### PR TITLE
docs: add correct argument getDocumentProxy in the Extract Text From PDF code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const buffer = await fetch(
 const buffer = await readFile("./dummy.pdf");
 
 // Load PDF from buffer
-const pdf = await getDocumentProxy(new Uint8Array(pdf));
+const pdf = await getDocumentProxy(new Uint8Array(buffer));
 // Extract text from PDF
 const { totalPages, text } = await extractText(pdf, { mergePages: true });
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

found wrong argument in the `getDocumentProxy` in the [Extract Text From PDF](https://github.com/unjs/unpdf?tab=readme-ov-file#extract-text-from-pdf) usage

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
