### PR TITLE
fix: export types from `pdfjs-dist`

### DIFF
--- a/src/pdfjs-serverless/rollup/plugins.ts
+++ b/src/pdfjs-serverless/rollup/plugins.ts
@@ -9,6 +9,7 @@ export function pdfjsTypes(): Plugin {
 import * as PDFJS from './types/src/pdf'
 declare function resolvePDFJS(): Promise<typeof PDFJS>
 export { resolvePDFJS }
+export * from './types/src/pdf'
 `.trimStart();
 
       for (const filename of ["pdfjs.d.ts", "pdfjs.d.mts"]) {


### PR DESCRIPTION
### 🔗 Linked issue

fixes #6

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added an export statement to the unpdf/pdfjs rollup plugin so that the types are exported and are usable by the library consumers.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
