### PR TITLE
fix: extract text concatenation

### DIFF
--- a/src/text.ts
+++ b/src/text.ts
@@ -43,7 +43,7 @@ async function getPageText(document: PDFDocumentProxy, pageNumber: number) {
     (content.items as TextItem[])
       // eslint-disable-next-line unicorn/no-null
       .filter((item) => item.str != null)
-      .map((item) => item.str)
-      .join(" ")
+      .map((item) => item.str + (item.hasEOL ? "\n" : ""))
+      .join("")
   );
 }


### PR DESCRIPTION
Currently the extractText function ignores line breaks and adds spaces between every chunk which results in broken results.

This PR is going to fix this.
