### PR TITLE
fix(extractImages): calculate channels correctly and return image metadata

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -20,6 +20,7 @@ export interface ExtractedImageObject {
   key: string
 }
 
+
 /**
  * Extracts images from a specific page of a PDF document, including necessary metadata,
  * such as width, height, and calculated color channels.
@@ -27,6 +28,18 @@ export interface ExtractedImageObject {
  * This version calculates channels based on image data length, width, and height,
  * as the `kind` property provided by PDF.js might not reliably indicate the actual
  * channel count of the raw pixel data (e.g., returning RGBA data even when kind is 3).
+ *
+ * @example
+ * const imagesData = await extractImages(pdf, pageNum)
+ *
+ * for (const imgData of imagesData) {
+ *   const imageIndex = totalImagesProcessed + 1;
+ *   await sharp(imgData.data, {
+ *     raw: { width: imgData.width, height: imgData.height, channels: imgData.channels }
+ *   })
+ *     .png()
+ *     .toFile(`${imageIndex}.png`);
+ * }
  */
 export async function extractImages(
   data: DocumentInitParameters['data'] | PDFDocumentProxy,

--- a/src/image.ts
+++ b/src/image.ts
@@ -21,12 +21,12 @@ export interface ExtractedImageObject {
 }
 
 /**
- * Extracts images from a specific page of a PDF document, including necessary metadata
- * like width, height, and calculated color channels.
+ * Extracts images from a specific page of a PDF document, including necessary metadata,
+ * such as width, height, and calculated color channels.
  *
  * This version calculates channels based on image data length, width, and height,
- * as the 'kind' property provided by pdfjs-dist might not reliably indicate the
- * actual channel count of the raw pixel data (e.g., returning RGBA data even when kind is 3).
+ * as the `kind` property provided by PDF.js might not reliably indicate the actual
+ * channel count of the raw pixel data (e.g., returning RGBA data even when kind is 3).
  */
 export async function extractImages(
   data: DocumentInitParameters['data'] | PDFDocumentProxy,
@@ -55,12 +55,11 @@ export async function extractImages(
     const image = await page.objs.get(imageKey)
 
     if (!image || !image.data || !image.width || !image.height) {
-      // Missing required properties.
+      // Missing required properties
       continue
     }
 
     const { width, height, data } = image
-
     const calculatedChannels = data.length / (width * height)
 
     if (![1, 3, 4].includes(calculatedChannels)) {
@@ -68,7 +67,7 @@ export async function extractImages(
         continue
     }
 
-    const channels = calculatedChannels as 1 | 3 | 4
+    const channels = calculatedChannels as ExtractedImageObject['channels']
 
     images.push({
       data,


### PR DESCRIPTION
Calculate image channels based on data length, width, and height.

`extractImages` now returns an array of objects containing `data`, `width`, `height`, `channels`, and `key` instead of just the raw data array. This fixes issues with distorted images caused by incorrect channel assumptions and provides necessary metadata for downstream processing.

resolves https://github.com/unjs/unpdf/issues/21

Example of extracting images to png format:

```ts
const imagesData = await extractImages(pdf, pageNum);

for (const imgData of imagesData) {
  const imageIndex = totalImagesProcessed + 1;

  try {
    await sharp(imgData.data, {
      raw: { width: imgData.width, height: imgData.height, channels: imgData.channels }
    })
    .png()
    .toFile(`${imageIndex}.png`);
  } catch (e) {
     // handle error
     continue;
  }
}
```

It is a breaking change because return value was changed, but given that this function was unusable before I have doubts it was in use anywhere