### PR TITLE
links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
 } from './image'
 import { getMeta as _getMeta } from './meta'
 import { extractText as _extractText } from './text'
+import { extractLinks as _extractLinks } from './link'
 import { resolvePDFJSImport } from './utils'
 
 export { configureUnPDF, definePDFJSModule } from './config'
@@ -33,4 +34,10 @@ export const extractImages: typeof _extractImages = async (...args) => {
 export const renderPageAsImage: typeof _renderPageAsImage = async (...args) => {
   await resolvePDFJSImport()
   return await _renderPageAsImage(...args)
+}
+
+export const extractLinks: typeof _extractLinks = async (...args) => {
+  await resolvePDFJSImport()
+  // @ts-expect-error: TS doesn't support overloads with default values
+  return await _extractLinks(...args)
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,7 @@ import {
   definePDFJSModule,
   extractImages,
   extractText,
+  extractLinks,
   getDocumentProxy,
   getMeta,
   getResolvedPDFJS,
@@ -58,6 +59,13 @@ describe('unpdf', () => {
 
     expect(text[0]).toMatchInlineSnapshot('"Dummy PDF file"')
     expect(totalPages).toMatchInlineSnapshot('1')
+  })
+
+  it('extracts links from a PDF', async () => {
+    const { links, totalPages } = await extractLinks(await getPDF('links.pdf'))
+    expect(links.length).toMatchInlineSnapshot('4')
+    expect(links[0]).toMatchInlineSnapshot('"https://www.antennahouse.com/"')
+    expect(totalPages).toMatchInlineSnapshot('2')
   })
 
   it('extracts images from a PDF', async () => {


### PR DESCRIPTION
This PR adds a method `extratLinks` which returns an array of all hyperlinks found in the PDF document using their annotations.

(It does NOT find hyperlinks that are simply in the text)

Added a new PDF file with 2 pages and 4 links and added the corresponding test.