### PR TITLE
feat: allow renderPageAsImage document options

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,19 @@ In order to use this method, make sure to meet the following requirements:
 - Use the official PDF.js build (see below for details).
 - Install the [`@napi-rs/canvas`](https://github.com/Brooooooklyn/canvas) package if you are using Node.js. This package is required to render the PDF page as an image.
 
+> [!NOTE]
+> If you need to pass PDF.js `getDocument` options (e.g. to improve font rendering), use the `document` option.
+>
+> ```ts
+> const result = await renderPageAsImage(buffer, pageNumber, {
+>   canvasImport: () => import('@napi-rs/canvas'),
+>   document: {
+>     disableFontFace: true,
+>     standardFontDataUrl: new URL('standard_fonts/', import.meta.url).toString(),
+>   },
+> })
+> ```
+
 **Type Declaration**
 
 ```ts
@@ -301,6 +314,7 @@ function renderPageAsImage(
     width?: number
     height?: number
     toDataURL?: false
+    document?: Omit<DocumentInitParameters, 'data' | 'CanvasFactory'>
   },
 ): Promise<ArrayBuffer>
 function renderPageAsImage(
@@ -313,6 +327,7 @@ function renderPageAsImage(
     width?: number
     height?: number
     toDataURL: true
+    document?: Omit<DocumentInitParameters, 'data' | 'CanvasFactory'>
   },
 ): Promise<string>
 ```

--- a/src/image.ts
+++ b/src/image.ts
@@ -98,6 +98,7 @@ export function renderPageAsImage(
     width?: number
     height?: number
     toDataURL?: false
+    document?: Omit<DocumentInitParameters, 'data' | 'CanvasFactory'>
   },
 ): Promise<ArrayBuffer>
 export function renderPageAsImage(
@@ -110,6 +111,7 @@ export function renderPageAsImage(
     width?: number
     height?: number
     toDataURL: true
+    document?: Omit<DocumentInitParameters, 'data' | 'CanvasFactory'>
   },
 ): Promise<string>
 export async function renderPageAsImage(
@@ -122,12 +124,25 @@ export async function renderPageAsImage(
     width?: number
     height?: number
     toDataURL?: boolean
+    document?: Omit<DocumentInitParameters, 'data' | 'CanvasFactory'>
   } = {},
 ) {
-  const CanvasFactory = await createIsomorphicCanvasFactory(options.canvasImport)
+  const {
+    canvasImport,
+    scale: requestedScale,
+    width,
+    height,
+    toDataURL,
+    document: documentOptions = {},
+  } = options
+
+  const CanvasFactory = await createIsomorphicCanvasFactory(canvasImport)
+  const safeDocumentOptions = { ...documentOptions } as DocumentInitParameters
+  delete safeDocumentOptions.data
+  delete safeDocumentOptions.CanvasFactory
   const pdf = isPDFDocumentProxy(data)
     ? data
-    : await getDocumentProxy(data, { CanvasFactory })
+    : await getDocumentProxy(data, { ...safeDocumentOptions, CanvasFactory })
   const page = await pdf.getPage(pageNumber)
 
   if (pageNumber < 1 || pageNumber > pdf.numPages) {
@@ -138,13 +153,13 @@ export async function renderPageAsImage(
   const defaultViewport = page.getViewport({ scale: 1.0 })
 
   // Calculate appropriate scale based on provided options
-  let scale = options.scale || 1.0
+  let scale = requestedScale || 1.0
 
-  if (options.width) {
-    scale = options.width / defaultViewport.width
+  if (width) {
+    scale = width / defaultViewport.width
   }
-  else if (options.height) {
-    scale = options.height / defaultViewport.height
+  else if (height) {
+    scale = height / defaultViewport.height
   }
 
   // Create the correctly scaled viewport
@@ -159,7 +174,7 @@ export async function renderPageAsImage(
 
   const dataUrl = drawingContext.canvas.toDataURL()
 
-  if (options.toDataURL) {
+  if (toDataURL) {
     return dataUrl
   }
 


### PR DESCRIPTION
## Summary
- allow passing PDF.js getDocument options via renderPageAsImage \\document\\ option
- document font rendering workaround in README

## Testing
- pnpm test

Co-Authored-By: Warp <agent@warp.dev>