### PR TITLE
fix(getDocumentProxy): add cMapUrl for CJK font support in Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ function getResolvedPDFJS(): Promise<PDFJS>
 
 Creates a `PDFDocumentProxy` from binary PDF data. Every extraction method accepts either raw data or an existing proxy – use this when you want to reuse one document across multiple calls.
 
-Applies sensible defaults: `isEvalSupported: false` and `useSystemFonts: true`; in Node.js additionally `disableFontFace: true` and `standardFontDataUrl` resolved from the local `pdfjs-dist` package (see the font rendering tip in [`renderPageAsImage`](#renderpageasimage)).
+Applies sensible defaults: `isEvalSupported: false` and `useSystemFonts: true`; in Node.js additionally `disableFontFace: true`, plus `standardFontDataUrl` and `cMapUrl`/`cMapPacked` resolved from the local `pdfjs-dist` package for standard font and CJK character map support (see the font rendering tip in [`renderPageAsImage`](#renderpageasimage)).
 
 **Type Declaration**
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ export const isBrowser = typeof window !== 'undefined'
  * In Node.js environments, additionally applies:
  * - `disableFontFace: true`
  * - `standardFontDataUrl` resolved from the local `pdfjs-dist` package
+ * - `cMapUrl` and `cMapPacked` resolved from the local `pdfjs-dist` package
  */
 export async function getDocumentProxy(
   data: DocumentInitParameters['data'],
@@ -32,6 +33,8 @@ export async function getDocumentProxy(
       nodeDefaults = {
         disableFontFace: true,
         standardFontDataUrl: new URL('./standard_fonts/', base).href,
+        cMapUrl: new URL('./cmaps/', base).href,
+        cMapPacked: true,
       }
     }
     catch {


### PR DESCRIPTION
When `pdfjs-dist` is available in Node.js, automatically resolve and pass `cMapUrl` (with `cMapPacked: true`) to the `getDocument` call, pointing to the package's bundled `cmaps/` directory.

### Problem
Rendering PDFs containing CJK/Asian fonts (Chinese, Japanese, Korean) produces warnings like:
```
Warning: loadFont - translateFont failed: "UnknownErrorException: Ensure that the `cMapUrl` API parameter is provided.".
Warning: Cannot substitute the font because of its name: ·½ÕýÊéËÎ-GBK
```

Previously only `standardFontDataUrl` was set (#15), but `cMapUrl` was omitted — PDF.js needs both for proper CJK character encoding lookup.

### Fix
Add `cMapUrl` and `cMapPacked: true` alongside the existing `standardFontDataUrl` in the Node.js defaults block:

```ts
nodeDefaults = {
  disableFontFace: true,
  standardFontDataUrl: new URL('./standard_fonts/', base).href,
  cMapUrl: new URL('./cmaps/', base).href,
  cMapPacked: true,
}
```

The fix is guarded by the same `try/catch` as `standardFontDataUrl` — serverless environments (where `pdfjs-dist` may not be installed) are unaffected.

### Related
- Continuation of: #15 (standard font support)
- Affects all users rendering CJK PDFs in Node.js, Deno, or Bun environments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF rendering in Node.js by automatically resolving character map resources and enabling packed character maps.
* **Documentation**
  * Updated `getDocumentProxy` documentation to clarify the expanded Node.js default behavior (including character map URL resolution and packed character maps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->