### PR TITLE
fix: resolve `@napi-rs/canvas` in the bundled PDF.js canvas factory

### DIFF
--- a/pdfjs.rollup.config.ts
+++ b/pdfjs.rollup.config.ts
@@ -4,12 +4,22 @@ import { defineConfig } from 'rollup'
 import esbuild, { minify } from 'rollup-plugin-esbuild'
 import { pdfjsTypes } from './src/pdfjs-serverless/rollup/plugins'
 
+// PDF.js resolves `@napi-rs/canvas` for its built-in `NodeCanvasFactory`, which
+// becomes the *document-level* canvas factory when no `CanvasFactory` option is
+// passed to `getDocument`. That factory is used for intermediate canvases (soft
+// masks, transparency groups, tiling patterns), so it must work whenever the
+// canvas module has been resolved via `resolveCanvasModule` — the resolved
+// module is shared through a well-known global symbol (see
+// `src/_internal/canvas.ts`). Without it, keep the descriptive error.
 const canvasMock = `
 new Proxy({}, {
   get(target, prop) {
+    const canvasModule = globalThis[Symbol.for("unpdf.canvasModule")];
+    if (canvasModule)
+      return canvasModule[prop];
     return () => {
-      throw new Error("@napi-rs/canvas is not available in this environment")
-    }
+      throw new Error("@napi-rs/canvas is not available in this environment");
+    };
   },
 })
 `
@@ -42,7 +52,8 @@ export default defineConfig({
         'if (!this.#modulePromise)': 'if (false)',
         '#instantiateWasm(fallbackCallback, imports, successCallback) {': '#instantiateWasm(fallbackCallback, imports, successCallback) { return;',
         '#getJsModule(fallbackCallback) {': '#getJsModule(fallbackCallback) { return;',
-        // Mock the `@napi-rs/canvas` module import from the unused `NodeCanvasFactory` class.
+        // Bridge the `@napi-rs/canvas` module import of PDF.js' `NodeCanvasFactory`
+        // to the module resolved by `resolveCanvasModule` (see `canvasMock` above).
         'require("@napi-rs/canvas")': canvasMock,
         // Remove the legacy build warning.
         'warn("Please use the `legacy` build in Node.js environments.")': '',

--- a/pdfjs.rollup.config.ts
+++ b/pdfjs.rollup.config.ts
@@ -4,13 +4,12 @@ import { defineConfig } from 'rollup'
 import esbuild, { minify } from 'rollup-plugin-esbuild'
 import { pdfjsTypes } from './src/pdfjs-serverless/rollup/plugins'
 
-// PDF.js resolves `@napi-rs/canvas` for its built-in `NodeCanvasFactory`, which
-// becomes the *document-level* canvas factory when no `CanvasFactory` option is
-// passed to `getDocument`. That factory is used for intermediate canvases (soft
-// masks, transparency groups, tiling patterns), so it must work whenever the
-// canvas module has been resolved via `resolveCanvasModule` — the resolved
-// module is shared through a well-known global symbol (see
-// `src/_internal/canvas.ts`). Without it, keep the descriptive error.
+// PDF.js' built-in `NodeCanvasFactory` becomes the document-level canvas
+// factory when no `CanvasFactory` option is passed to `getDocument` and is
+// asked for intermediate canvases (soft masks, transparency groups, tiling
+// patterns). Bridge its `@napi-rs/canvas` require to the module shared by
+// `resolveCanvasModule` through a well-known global symbol; without a
+// resolved module, keep the descriptive error.
 const canvasMock = `
 new Proxy({}, {
   get(target, prop) {
@@ -18,8 +17,8 @@ new Proxy({}, {
     if (canvasModule)
       return canvasModule[prop];
     return () => {
-      throw new Error("@napi-rs/canvas is not available in this environment");
-    };
+      throw new Error("@napi-rs/canvas is not available in this environment")
+    }
   },
 })
 `
@@ -52,8 +51,7 @@ export default defineConfig({
         'if (!this.#modulePromise)': 'if (false)',
         '#instantiateWasm(fallbackCallback, imports, successCallback) {': '#instantiateWasm(fallbackCallback, imports, successCallback) { return;',
         '#getJsModule(fallbackCallback) {': '#getJsModule(fallbackCallback) { return;',
-        // Bridge the `@napi-rs/canvas` module import of PDF.js' `NodeCanvasFactory`
-        // to the module resolved by `resolveCanvasModule` (see `canvasMock` above).
+        // Bridge the `@napi-rs/canvas` module import from the `NodeCanvasFactory` class.
         'require("@napi-rs/canvas")': canvasMock,
         // Remove the legacy build warning.
         'warn("Please use the `legacy` build in Node.js environments.")': '',

--- a/pdfjs.rollup.config.ts
+++ b/pdfjs.rollup.config.ts
@@ -13,17 +13,15 @@ import { pdfjsTypes } from './src/pdfjs-serverless/rollup/plugins'
 const canvasMock = `
 new Proxy({}, {
   get(target, prop) {
-    const canvasModule = globalThis[Symbol.for("unpdf.canvasModule")];
+    const canvasModule = globalThis[Symbol.for("unpdf.canvasModule")]
     if (canvasModule)
-      return canvasModule[prop];
+      return canvasModule[prop]
     return () => {
       throw new Error("@napi-rs/canvas is not available in this environment")
     }
   },
 })
-`
-  .replaceAll('\n', '')
-  .trim()
+`.trim()
 
 export default defineConfig({
   input: 'src/pdfjs-serverless/index.mjs',

--- a/src/_internal/canvas.ts
+++ b/src/_internal/canvas.ts
@@ -96,6 +96,13 @@ export class NodeCanvasFactory extends BaseCanvasFactory {
 
 export async function resolveCanvasModule(canvasImport: () => Promise<typeof import('@napi-rs/canvas')>) {
   resolvedCanvasModule ??= (await interopDefault(canvasImport()))
+
+  // Share the resolved module with the serverless PDF.js build: its baked-in
+  // `NodeCanvasFactory` (the default document-level factory of `getDocument`,
+  // used for intermediate canvases such as soft masks and transparency groups)
+  // resolves `@napi-rs/canvas` through this global symbol — see the canvas mock
+  // in `pdfjs.rollup.config.ts`.
+  ;(globalThis as Record<symbol, unknown>)[Symbol.for('unpdf.canvasModule')] = resolvedCanvasModule
 }
 
 /**

--- a/src/_internal/canvas.ts
+++ b/src/_internal/canvas.ts
@@ -100,9 +100,8 @@ export async function resolveCanvasModule(canvasImport: () => Promise<typeof imp
   // Share the resolved module with the serverless PDF.js build: its baked-in
   // `NodeCanvasFactory` (the default document-level factory of `getDocument`,
   // used for intermediate canvases such as soft masks and transparency groups)
-  // resolves `@napi-rs/canvas` through this global symbol — see the canvas mock
-  // in `pdfjs.rollup.config.ts`.
-  ;(globalThis as Record<symbol, unknown>)[Symbol.for('unpdf.canvasModule')] = resolvedCanvasModule
+  // resolves `@napi-rs/canvas` through this global symbol.
+  ;(globalThis as Record<PropertyKey, unknown>)[Symbol.for('unpdf.canvasModule')] = resolvedCanvasModule
 }
 
 /**

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -6,3 +6,4 @@ PDF files have been added to the repository for testing purposes. These files ar
 
 - [w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf](https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf)
 - [github.com/py-pdf/sample-files](https://github.com/py-pdf/sample-files)
+- `transparency.pdf`: handcrafted minimal PDF whose page content applies a luminosity soft mask (`/SMask` in `/ExtGState`), forcing PDF.js to request an intermediate canvas from the document-level canvas factory

--- a/test/fixtures/transparency.pdf
+++ b/test/fixtures/transparency.pdf
@@ -1,0 +1,35 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /ExtGState << /GS0 << /Type /ExtGState /SMask << /Type /Mask /S /Luminosity /G 5 0 R >> >> >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 37 >>
+stream
+q /GS0 gs 1 0 0 rg 0 0 200 200 re f Q
+endstream
+endobj
+5 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 200 200] /Group << /S /Transparency /CS /DeviceGray >> /Length 22 >>
+stream
+0.5 g 0 0 200 200 re f
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000313 00000 n 
+0000000400 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+568
+%%EOF

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -137,6 +137,21 @@ describe('unpdf', () => {
     expect(result.startsWith('data:image/png;base64,')).toBe(true)
   })
 
+  it('renders a page with a soft mask from a pre-built document proxy', async () => {
+    // Intermediate canvases (soft masks, transparency groups) are requested from
+    // the document-level canvas factory, which for a proxy created without the
+    // `CanvasFactory` option is the built-in PDF.js one — it must resolve
+    // `@napi-rs/canvas` once `canvasImport` has been provided.
+    // See https://github.com/unjs/unpdf/issues/53
+    const pdf = await getDocumentProxy(await getPDF('transparency.pdf'))
+    const result = await renderPageAsImage(pdf, 1, {
+      canvasImport: () => import('@napi-rs/canvas'),
+    })
+
+    const headerBytes = new Uint8Array(result, 0, 8)
+    expect(Array.from(headerBytes)).toEqual([137, 80, 78, 71, 13, 10, 26, 10])
+  })
+
   it('supports passing PDFDocumentProxy', async () => {
     const pdf = await getDocumentProxy(await getPDF())
     const { info } = await getMeta(pdf)


### PR DESCRIPTION
Fixes #53.

### The problem

The canvas mock in `pdfjs.rollup.config.ts` replaces the `require("@napi-rs/canvas")` of PDF.js' built-in `NodeCanvasFactory` with an always-throwing proxy, with the comment calling that class "unused". It isn't quite: when `getDocumentProxy` is called without the `CanvasFactory` option, that class becomes the *document-level* canvas factory, which PDF.js asks for intermediate canvases — soft masks, transparency groups, tiling patterns. So `renderPageAsImage(prebuiltProxy, n, { canvasImport })` failed on pages containing those constructs (e.g. most PDFs exported from slide decks) with:

```
Error: @napi-rs/canvas is not available in this environment
```

while simple pages rendered fine, making it look like a packaging/environment issue.

### The fix

- `resolveCanvasModule` now shares the resolved canvas module through a well-known global symbol (`Symbol.for("unpdf.canvasModule")`) — the only channel available between the two separately-built bundles.
- The canvas mock in the serverless PDF.js build resolves the module from that symbol, falling back to the existing descriptive error when nothing has been resolved.

No API changes: as soon as `canvasImport` is provided (to `renderPageAsImage` or `createIsomorphicCanvasFactory`), the built-in factory of any document proxy — pre-built or not — starts working. When it isn't, behavior is unchanged.

### Tests

Added `test/fixtures/transparency.pdf` (handcrafted minimal PDF with a luminosity `/SMask` in `/ExtGState`, which forces an intermediate canvas) and a test rendering it from a pre-built proxy. The test fails against the previous `dist/pdfjs.mjs` and passes after the change; the full suite (12 tests), `pnpm lint`, and `pnpm test:types` pass.

Also verified against the real-world PDF from #53's originating case: all 16 pages render; before the change, 5 of them threw.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved canvas-module handling to better support different rendering environments, including cases where an intermediate canvas is required.
  * Fixed rendering for PDFs with transparency/soft masks so output is generated correctly.
* **Tests**
  * Added a test that renders a soft-mask (transparency) PDF and verifies the result is a valid PNG.
* **Documentation**
  * Documented a new `transparency.pdf` fixture, including that it uses a luminosity soft mask to trigger intermediate canvas rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->