### PR TITLE
fix: add .js extension to relative imports in .d.mts & .d.cts files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm run build:pdfjs
+      - run: pnpm run build
       - run: pnpm run test:types
+      - run: pnpm run test:types:dist
       - run: pnpm run lint
       - run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "lint:fix": "eslint . --fix",
     "release": "bumpp",
     "test": "vitest",
-    "test:types": "tsc --noEmit"
+    "test:types": "tsc --noEmit",
+    "test:types:dist": "tsc -p test/types/tsconfig.json"
   },
   "peerDependencies": {
     "@napi-rs/canvas": "^0.1.69"

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -5,20 +5,29 @@ import { fileURLToPath } from 'node:url'
 import { glob } from 'tinyglobby'
 
 const rootDir = fileURLToPath(new URL('..', import.meta.url))
-const targets = await glob(['dist/**/*.{d.cts,d.mts,d.ts}'], {
+
+const bundleDeclarations = await glob(['dist/**/*.{d.cts,d.mts,d.ts}'], {
   cwd: rootDir,
   ignore: ['**/types/**'],
 })
 
-for (const filename of targets) {
+for (const filename of bundleDeclarations) {
   await relativeTypePaths(filename)
+}
+
+const vendoredDeclarations = await glob(['dist/types/**/*.d.ts'], {
+  cwd: rootDir,
+})
+
+for (const filename of vendoredDeclarations) {
+  await explicitImportExtensions(filename)
 }
 
 /**
  * @param {string} filename
  */
 async function relativeTypePaths(filename) {
-  let content = await fsp.readFile(filename, 'utf8')
+  let content = await fsp.readFile(path.resolve(rootDir, filename), 'utf8')
   if (!content.includes('pdfjs-dist/types'))
     return
 
@@ -33,4 +42,32 @@ async function relativeTypePaths(filename) {
   content = content.replace(/pdfjs-dist\/types/g, base)
 
   await fsp.writeFile(path.resolve(rootDir, filename), content, 'utf8')
+}
+
+/**
+ * The type declarations copied from `pdfjs-dist` are generated from JSDoc and
+ * partly reference sibling modules without file extensions. Under
+ * `moduleResolution: "nodenext"`, extensionless relative imports resolve to
+ * error types, so append the missing `.js` extensions.
+ *
+ * @param {string} filename
+ */
+async function explicitImportExtensions(filename) {
+  const content = await fsp.readFile(path.resolve(rootDir, filename), 'utf8')
+
+  const patchedContent = content
+    .replace(/(from\s+)(["'])(\.[^"']+)\2/g, (_, importFrom, quote, specifier) =>
+      `${importFrom}${quote}${appendJsExtension(specifier)}${quote}`)
+    .replace(/(import\()(["'])(\.[^"']+)\2/g, (_, importCall, quote, specifier) =>
+      `${importCall}${quote}${appendJsExtension(specifier)}${quote}`)
+
+  if (patchedContent !== content)
+    await fsp.writeFile(path.resolve(rootDir, filename), patchedContent, 'utf8')
+}
+
+/**
+ * @param {string} specifier
+ */
+function appendJsExtension(specifier) {
+  return specifier.endsWith('.js') ? specifier : `${specifier}.js`
 }

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -29,7 +29,7 @@ async function relativeTypePaths(filename) {
 
   // Replace `pdfjs-dist/types` import path with relative path and add `.js` extension
   const base = relativePath.startsWith('.') ? relativePath : `./${relativePath}`
-  content = content.replace(/pdfjs-dist\/types(\/[^'";\s]+(?<!\.js))/g, `${base}$1.js`)
+  content = content.replace(/pdfjs-dist\/types(\/[^'";\s]+?)(?:\.js)?(?=['"])/g, `${base}$1.js`)
   content = content.replace(/pdfjs-dist\/types/g, base)
 
   await fsp.writeFile(path.resolve(rootDir, filename), content, 'utf8')

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -27,11 +27,10 @@ async function relativeTypePaths(filename) {
     path.resolve(rootDir, 'dist/types'),
   )
 
-  // Replace `pdfjs-dist/types` import path with relative path
-  content = content.replace(
-    /pdfjs-dist\/types/g,
-    relativePath.startsWith('.') ? relativePath : `./${relativePath}`,
-  )
+  // Replace `pdfjs-dist/types` import path with relative path and add `.js` extension
+  const base = relativePath.startsWith('.') ? relativePath : `./${relativePath}`
+  content = content.replace(/pdfjs-dist\/types(\/[^'";\s]+(?<!\.js))/g, `${base}$1.js`)
+  content = content.replace(/pdfjs-dist\/types/g, base)
 
   await fsp.writeFile(path.resolve(rootDir, filename), content, 'utf8')
 }

--- a/src/pdfjs-serverless/rollup/plugins.ts
+++ b/src/pdfjs-serverless/rollup/plugins.ts
@@ -5,8 +5,10 @@ export function pdfjsTypes(): Plugin {
   return {
     name: 'pdfjs-serverless:types',
     async writeBundle() {
+      // The explicit `.js` extension keeps the declarations resolvable under
+      // `moduleResolution: "nodenext"`.
       const typeExports = `
-export * from './types/src/pdf'
+export * from './types/src/pdf.js'
 `.trimStart()
 
       for (const filename of ['pdfjs.d.ts', 'pdfjs.d.mts']) {

--- a/test/types/nodenext.mts
+++ b/test/types/nodenext.mts
@@ -1,0 +1,19 @@
+/**
+ * Compile-only consumer of the built package: `tsc` resolves the shipped
+ * declarations the way a `moduleResolution: "nodenext"` project does, with
+ * `skipLibCheck` disabled so extensionless imports inside the declaration
+ * files fail the check instead of degrading to error types.
+ *
+ * Requires `pnpm run build:pdfjs && pnpm run build` beforehand.
+ */
+import type { PDFDocumentProxy } from 'unpdf/pdfjs'
+import { extractText, getDocumentProxy, getMeta } from 'unpdf'
+
+export async function consumeBuiltDeclarations(data: Uint8Array) {
+  const pdf: PDFDocumentProxy = await getDocumentProxy(data)
+  const { text } = await extractText(pdf, { mergePages: true })
+  const mergedText: string = text
+  const { info } = await getMeta(pdf)
+
+  return { pdf, mergedText, info }
+}

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "include": ["nodenext.mts"]
+}

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "types": ["node"],
-    "strict": true,
     "noEmit": true,
     "skipLibCheck": false
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "noEmit": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["node_modules", "test/types"]
 }


### PR DESCRIPTION
Fixes #55. Repro is available in the issue.





_**Disclaimer**: This is my first time contributing to open source. I would appreciate guidance from the fellow travellers. Thank you!_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated TypeScript declaration references so they resolve correctly under Node ESM (`nodenext`) module resolution.
  * Enhanced declaration post-processing to normalize relative import paths and automatically add missing `.js` extensions, including dynamic `import()` cases.
* **Tests**
  * Added Node ESM compile-time checks to validate both development and built declaration outputs.
* **CI**
  * Extended the workflow to run the additional TypeScript declaration checks after the build completes.
* **Chores**
  * Updated TypeScript configuration to exclude non-target folders from compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->