### PR TITLE
docs: hardening guidance for untrusted PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,15 @@ const html = `<!DOCTYPE html>
 await writeFile('dummy-page-1.html', html)
 ```
 
+## Processing Untrusted PDFs
+
+The `getDocumentProxy` defaults are safe against script execution (`isEvalSupported: false`), but resource limits are your job:
+
+- **Image decoding:** `maxImageSize` is unlimited by default – pass e.g. `maxImageSize: 16_777_216` (~16 MP) so a single declared image can't allocate gigabytes.
+- **Page fan-out:** `extractText`, `extractTextItems`, and `extractLinks` process all pages in one call – check `pdf.numPages` against a limit first.
+- **Timeouts:** with the serverless build, parsing runs on your event loop (no worker) – race extraction calls against a timeout.
+- The raw `getDocument` from `unpdf/pdfjs` applies none of these defaults.
+
 ## License
 
 [MIT](./LICENSE) License © 2023-PRESENT [Johann Schopplich](https://github.com/johannschopplich)


### PR DESCRIPTION
Follow-up to #59, covering the documentation half of the request. Adds a compact "Processing Untrusted PDFs" README section – bounding `maxImageSize` (unlimited by default in PDF.js), bounding page fan-out for the all-pages extraction helpers, wrapping calls in a timeout since the bundled build parses on the caller's event loop, and the note that `unpdf/pdfjs`'s raw `getDocument` bypasses every `getDocumentProxy` default.

API-level options from #59 (`maxPages`, a bounded `maxImageSize` default) stay open for now – docs first, options when a concrete case asks for them.

https://claude.ai/code/session_01JcB4pJwCEPaS3MFQm2J7ao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for safely processing untrusted PDFs.
  * Documented secure defaults that prevent script execution.
  * Added recommendations for limiting image sizes, page processing, and extraction timeouts.
  * Clarified limitations of serverless processing and the lower-level PDF loading option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->